### PR TITLE
feat(accessibility): add filter button and announce date selection for improved screen reader support

### DIFF
--- a/lib/agenda/agenda_page.dart
+++ b/lib/agenda/agenda_page.dart
@@ -1,6 +1,7 @@
 import 'package:conf_shared_models/conf_shared_models.dart';
 import 'package:conf_ui_kit/conf_ui_kit.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_conf_latam/extensions/navigator_extensions.dart';
 import 'package:flutter_conf_latam/l10n/l10n.dart';
 import 'package:flutter_conf_latam/mock/mock_data.dart';
@@ -80,10 +81,52 @@ class _AgendaPageState extends State<AgendaPage> {
     }
   }
 
+  Widget _buildFilterButton(BuildContext context) {
+    final l10n = context.l10n;
+    final textTheme = context.textTheme;
+    final colorScheme = context.colorScheme;
+
+    return SliverToBoxAdapter(
+      child: SizedBox(
+        width: double.infinity,
+        child: Semantics(
+          label: l10n.filterButtonLabel,
+          button: true,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: OutlinedButton.icon(
+              onPressed: () {},
+              icon: Icon(Icons.filter_list, color: colorScheme.primary),
+              label: Text(
+                l10n.filterButtonLabel,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.primary,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   void _onDateSelected(DateTime date) {
     setState(() {
       _selectedDate = date;
     });
+
+    _announceSelectedDate(date);
+  }
+
+  void _announceSelectedDate(DateTime date) {
+    final l10n = context.l10n;
+    final formatter = DateFormatService.withContext(context);
+
+    // Announce date change to screen readers
+    SemanticsService.announce(
+      l10n.dateSelectedAnnouncement(formatter.formatFullDate(date)),
+      TextDirection.ltr,
+    );
   }
 
   @override
@@ -145,24 +188,18 @@ class _AgendaPageState extends State<AgendaPage> {
 
     return CustomScrollView(
       slivers: [
-        SliverPadding(
-          padding: EdgeInsets.fromLTRB(
-            UiConstants.spacing16,
-            topPadding + UiConstants.spacing16,
-            UiConstants.spacing16,
-            0,
-          ),
-          sliver: SliverToBoxAdapter(
-            child: Semantics(
-              header: true,
-              child: DatesTabs(
-                availableDates: _dates,
-                selectedDate: selectedDate,
-                onDateSelected: _onDateSelected,
-              ),
-            ),
+        SliverPinnedHeader(
+          child: AgendaHeader(
+            availableDates: _dates,
+            selectedDate: selectedDate,
+            onDateSelected: _onDateSelected,
+            onFavoriteTap: () => debugPrint('Favorite tapped'),
+            favoriteSessionsLabel: l10n.favoriteSessionsLabel,
+            favoriteSessionsTooltip: l10n.favoriteSessionsTooltip,
           ),
         ),
+        _buildFilterButton(context),
+
         SliverPadding(
           padding: EdgeInsets.fromLTRB(
             UiConstants.spacing16,

--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -10,14 +10,14 @@ import 'package:flutter_conf_latam/speaker_details/speaker_details.dart';
 class Homepage extends StatelessWidget {
   const Homepage({required this.onNavigateToVenue, super.key});
 
-  final VoidCallback onNavigateToVenue;
-
   static const _contentPadding = EdgeInsets.fromLTRB(
     UiConstants.spacing16,
     UiConstants.spacing16,
     UiConstants.spacing16,
     0,
   );
+
+  final VoidCallback onNavigateToVenue;
 
   @override
   Widget build(BuildContext context) {
@@ -41,6 +41,10 @@ class Homepage extends StatelessWidget {
     final sessions = ConferenceMockData.getSessionsList();
     final speakers = ConferenceMockData.getSpeakers();
 
+    const venueName = 'Universidad de las Américas';
+    const location = 'Quito, Ecuador';
+    final dates = l10n.conferenceDates(9, 10);
+
     return Semantics(
       container: true,
       label: l10n.homeTabLabel,
@@ -53,9 +57,15 @@ class Homepage extends StatelessWidget {
                 VenueBanner(
                   title: l10n.venueBannerTitle,
                   imagePath: 'assets/images/udla.webp',
-                  venueName: 'Universidad de las Américas',
-                  location: 'Quito, Ecuador',
-                  dates: l10n.conferenceDates(9, 10),
+                  venueName: venueName,
+                  location: location,
+                  dates: dates,
+                  semanticLabel: l10n.venueBannerSemanticLabel(
+                    venueName,
+                    location,
+                    dates,
+                  ),
+                  semanticHint: l10n.venueBannerSemanticsHint,
                   onTap: onNavigateToVenue,
                 ),
                 const ExcludeSemantics(


### PR DESCRIPTION
## What

1. Added date selection in the agenda with accessibility announcements for assistive technology users.
2. Extracted venue details into constants on the home page to improve code readability and maintainability.

## Why

1. Improve accessibility for users relying on screen readers.
3. Reduce duplication and enhance clarity in venue data management.