### PR TITLE
fix: synchronize hit testing with painted region in SliverPinnedHeader

### DIFF
--- a/packages/conf_ui_kit/lib/src/sliver/sliver_pinned_header.dart
+++ b/packages/conf_ui_kit/lib/src/sliver/sliver_pinned_header.dart
@@ -61,4 +61,28 @@ class RenderSliverPinnedHeader extends RenderSliverSingleBoxAdapter {
     // Position the child at the top of the viewport when pinned
     (child!.parentData! as SliverPhysicalParentData).paintOffset = Offset.zero;
   }
+
+  @override
+  bool hitTest(
+    SliverHitTestResult result, {
+    required double mainAxisPosition,
+    required double crossAxisPosition,
+  }) {
+    if (child == null) return false;
+
+    // When pinned, always test against the painted position
+    final paintedChildSize = math.min(
+      child!.size.height,
+      constraints.remainingPaintExtent,
+    );
+
+    if (mainAxisPosition >= 0 && mainAxisPosition < paintedChildSize) {
+      return child!.hitTest(
+        BoxHitTestResult.wrap(result),
+        position: Offset(crossAxisPosition, mainAxisPosition),
+      );
+    }
+
+    return false;
+  }
 }


### PR DESCRIPTION
## What
- Fixed hit testing inconsistency in `SliverPinnedHeader` by overriding the `hitTest` method

## Why

- Resolves tap gestures passing through visible header areas without detection
- Improves user experience by ensuring visible header taps are handled correctly
- Aligns hit test behavior with painted regions for reliable interaction