### PR TITLE
refactor: remove unnecessary ExcludeSemantics and perform semantic cleanup

### DIFF
--- a/packages/conf_ui_kit/lib/src/app_bar/frosted_app_bar.dart
+++ b/packages/conf_ui_kit/lib/src/app_bar/frosted_app_bar.dart
@@ -84,9 +84,7 @@ class FrostedAppBar extends StatelessWidget implements PreferredSizeWidget {
                 children: [
                   if (effectiveLeading != null) ...[
                     effectiveLeading,
-                    const ExcludeSemantics(
-                      child: SizedBox(width: UiConstants.spacing16),
-                    ),
+                    const SizedBox(width: UiConstants.spacing16),
                   ],
 
                   if (title != null)

--- a/packages/conf_ui_kit/lib/src/banners/venue_banner.dart
+++ b/packages/conf_ui_kit/lib/src/banners/venue_banner.dart
@@ -30,7 +30,7 @@ class VenueBanner extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(title),
-        const ExcludeSemantics(child: SizedBox(height: 4)),
+        const SizedBox(height: UiConstants.spacing4),
         _BannerCard(
           venueName: venueName,
           location: location,

--- a/packages/conf_ui_kit/lib/src/cards/info_card.dart
+++ b/packages/conf_ui_kit/lib/src/cards/info_card.dart
@@ -50,9 +50,7 @@ class InfoCard extends StatelessWidget {
                         color: iconColor ?? colorScheme.primary,
                       ),
                     ),
-                    const ExcludeSemantics(
-                      child: SizedBox(width: UiConstants.spacing8),
-                    ),
+                    const SizedBox(width: UiConstants.spacing8),
                     Expanded(
                       child: Semantics(
                         header: true,
@@ -67,9 +65,7 @@ class InfoCard extends StatelessWidget {
                   ],
                 ),
               ),
-              const ExcludeSemantics(
-                child: SizedBox(height: UiConstants.spacing8),
-              ),
+              const SizedBox(height: UiConstants.spacing8),
               Text(description, style: textTheme.bodyMedium),
             ],
           ),

--- a/packages/conf_ui_kit/lib/src/cards/speaker_card.dart
+++ b/packages/conf_ui_kit/lib/src/cards/speaker_card.dart
@@ -46,9 +46,7 @@ class SpeakerCard extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 SpeakerAvatar(speaker: speaker, size: cardSize.avatarSize),
-                const ExcludeSemantics(
-                  child: SizedBox(width: UiConstants.spacing16),
-                ),
+                const SizedBox(width: UiConstants.spacing16),
                 Expanded(
                   child: ExcludeSemantics(
                     child: Column(
@@ -63,15 +61,6 @@ class SpeakerCard extends StatelessWidget {
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                         ),
-                        // if (showBio && speaker.description.isNotEmpty) ...[
-                        //   const SizedBox(height: UiConstants.spacing8),
-                        //   Text(
-                        //     speaker.description,
-                        //     style: textTheme.bodySmall,
-                        //     maxLines: maxBioLines,
-                        //     overflow: TextOverflow.ellipsis,
-                        //   ),
-                        // ],
                       ],
                     ),
                   ),

--- a/packages/conf_ui_kit/lib/src/lists/icon_label_list.dart
+++ b/packages/conf_ui_kit/lib/src/lists/icon_label_list.dart
@@ -33,7 +33,7 @@ class IconLabelList extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             for (int i = 0; i < items.length; i++) ...[
-              if (i > 0) ExcludeSemantics(child: SizedBox(height: spacing)),
+              if (i > 0) SizedBox(height: spacing),
               _IconLabelRow(item: items[i]),
             ],
           ],

--- a/packages/conf_ui_kit/lib/src/sections/speakers_section.dart
+++ b/packages/conf_ui_kit/lib/src/sections/speakers_section.dart
@@ -15,6 +15,10 @@ class SpeakersSection extends StatelessWidget {
     super.key,
   });
 
+  static const EdgeInsets _itemPadding = EdgeInsets.symmetric(
+    horizontal: UiConstants.spacing2,
+  );
+
   /// Title for the section
   final String sectionTitle;
 
@@ -35,16 +39,14 @@ class SpeakersSection extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SectionTitle(title: sectionTitle),
-          const ExcludeSemantics(child: SizedBox(height: UiConstants.spacing8)),
+          const SizedBox(height: UiConstants.spacing8),
           SingleChildScrollView(
             scrollDirection: Axis.horizontal,
             child: Row(
               children: [
                 for (final speaker in speakers)
                   Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: UiConstants.spacing2,
-                    ),
+                    padding: _itemPadding,
                     child: _SpeakerItem(
                       speaker: speaker,
                       onTap: () => onSpeakerTap(speaker),
@@ -62,6 +64,12 @@ class SpeakersSection extends StatelessWidget {
 class _SpeakerItem extends StatelessWidget {
   const _SpeakerItem({required this.speaker, required this.onTap});
 
+  static const Widget _verticalSpacing = SizedBox(height: UiConstants.spacing8);
+
+  static const EdgeInsets _speakerNamePadding = EdgeInsets.symmetric(
+    vertical: UiConstants.spacing8,
+  );
+
   final SpeakerSummary speaker;
   final VoidCallback onTap;
 
@@ -78,13 +86,9 @@ class _SpeakerItem extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             SpeakerAvatar(speaker: speaker),
-            const ExcludeSemantics(
-              child: SizedBox(height: UiConstants.spacing8),
-            ),
+            _verticalSpacing,
             Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: UiConstants.spacing8,
-              ),
+              padding: _speakerNamePadding,
               child: SizedBox(
                 width: UiConstants.speakerCardWidth,
                 child: Text(


### PR DESCRIPTION
## What 

- Removed unnecessary `ExcludeSemantics` wrappers 
- Removed commented-out code in `speaker_card.dart` 
- Extracted padding constants in `speakers_section.dart` for improved readability 

## Why 

- Simplifies widget trees and improves semantic structure 
- Promotes cleaner, more maintainable code 
- Eliminates unused or redundant elements without affecting functionality