### PR TITLE
fix: remove UTC to local conversion

### DIFF
--- a/packages/agenda_repository/lib/src/agenda_repository.dart
+++ b/packages/agenda_repository/lib/src/agenda_repository.dart
@@ -139,16 +139,6 @@ class AgendaRepository {
       );
     }
 
-    if (normalized['startDate'] != null) {
-      final utcDate = DateTime.parse(normalized['startDate'] as String);
-      normalized['startDate'] = utcDate.toLocal().toIso8601String();
-    }
-
-    if (normalized['endDate'] != null) {
-      final utcDate = DateTime.parse(normalized['endDate'] as String);
-      normalized['endDate'] = utcDate.toLocal().toIso8601String();
-    }
-
     return normalized;
   }
 }


### PR DESCRIPTION
## What

- Removed the UTC to local time conversion that was causing incorrect time displays  

## Why  

- Eliminates errors caused by improper timezone conversions  
